### PR TITLE
fix: add `repository` entry in `package.json` for `auto`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@tylertech/forge-cli",
   "version": "1.0.0-dev.0",
   "description": "A command line interface for managing Forge Web Component projects.",
+  "repository": "tyler-technologies/forge-cli",
   "bin": {
     "forge": "bin/forge"
   },


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.0--canary.2.2103521413.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tylertech/forge-cli@1.0.0--canary.2.2103521413.0 --registry https://tylertech.jfrog.io/artifactory/api/npm/scratch-npm-local/
  # or 
  yarn add @tylertech/forge-cli@1.0.0--canary.2.2103521413.0 --registry https://tylertech.jfrog.io/artifactory/api/npm/scratch-npm-local/
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
