### PR TITLE
feat(build): copy bundled ESM output to npm package

### DIFF
--- a/src/commands/build/build-command.ts
+++ b/src/commands/build/build-command.ts
@@ -5,7 +5,7 @@ import { FULL_BUILD_DIR_NAME, TEMP_BUILD_DIR_NAME } from '../../constants';
 import { ICommand, ICommandOption, ICommandParameter } from '../../core/command';
 import { cleanup, IBuildTaskConfiguration, lintTask } from '../../utils/build-utils';
 import { assertBoolean, getTimeStamp } from '../../utils/utils';
-import { build, copyStaticDistributionAssets, createDistributionPackage, prebuild } from './build-command-utils';
+import { build, copyBundledDistributionAssets, createDistributionPackage, prebuild } from './build-command-utils';
 
 /** The command definition for the main library build. */
 export class BuildCommand implements ICommand {
@@ -67,6 +67,6 @@ export async function buildCommand(ctx: IBuildTaskConfiguration): Promise<void> 
   await prebuild({ buildRoot, buildDir: buildRoot, buildOutputDir, srcDir, quiet: ctx.quiet });
   await build({ config: ctx, buildOutputDir, quiet: ctx.quiet });
   await createDistributionPackage({ config: ctx, packageJson, buildOutputDir });
-  await copyStaticDistributionAssets({ config: ctx, packageJson, buildOutputDir });
+  await copyBundledDistributionAssets({ config: ctx, packageJson, buildOutputDir });
   await cleanup(buildOutputDir, ctx.quiet);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The `build` command will now copy the bundled ESM output from `esbuild` into the distribution npm package within the `dist/esm/` directory.

## Additional information
This will enable easy consumption of ESM from public CDNs, such as unpkg and jsdelivr, without the need for import maps  because this build is bundled, code-split, and doesn't include bare module specifiers.
