### PR TITLE
fix(build): fix to re-enable minification of ESM distribution files

### DIFF
--- a/src/utils/build-utils.ts
+++ b/src/utils/build-utils.ts
@@ -82,6 +82,7 @@ export async function generateStaticESModuleSources({
     chunkNames: 'chunks/[name].[hash]',
     sourcemap: true,
     bundle: true,
+    minify: true,
     metafile,
     outdir,
     external


### PR DESCRIPTION
All ESM distribution files now be properly minified by default.
