### PR TITLE
feat(build): allow for configurable esbuild target and other build options

### DIFF
--- a/config/schema.json
+++ b/config/schema.json
@@ -289,6 +289,48 @@
               }
             }
           }
+        },
+        "esbuild": {
+          "description": "Additional options to provide to esbuild during compilation.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "target": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "The target environment to compile to.",
+                  "default": ""
+                },
+                {
+                  "type": "array",
+                  "description": "The target environment to compile to.",
+                  "default": "",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "supported": {
+              "type": "object",
+              "description": "The externals definition for external modules.",
+              "additionalProperties": {
+                "type": ["string", "boolean"],
+                "description": "List of JavaScript syntax features to include in the compilation."
+              }
+            },
+            "minify": {
+              "type": "boolean",
+              "description": "Whether to minify the output or not.",
+              "default": true
+            },
+            "bundle": {
+              "type": "boolean",
+              "description": "Whether to bundle external dependencies in the output or not.",
+              "default": true
+            }
+          }
         }
       }
     },

--- a/src/commands/build/build-command-utils.ts
+++ b/src/commands/build/build-command-utils.ts
@@ -1,14 +1,16 @@
 import { join, parse, resolve } from 'canonical-path';
 import ts from 'typescript';
 import {
+  absolutify,
   copyFilesAsync,
   copyFilesMultiple,
   deleteDir,
+  existsAsync,
   globFilesAsync,
   IFileCopyConfig,
   IPackageJson,
   mkdirp,
-  runCommand,
+  readJsonFile,
   runTask,
   writeFileAsync
 } from '@tylertech/forge-build-tools';
@@ -105,10 +107,22 @@ export async function build({
     const libEntry = join(stagingSrcDir, `${entryName}.ts`);
     const componentEntries = await globFilesAsync(join(stagingSrcDir, '**/index.ts')) as string[];
 
+    // Attempt to inherit the ES build target from the build tsconfig if we don't have one set in the project configuration
+    let buildTarget = config.context.build.esbuild.target;
+    const tsconfigPath = absolutify(config.context.build.tsconfigPath, config.context.paths.rootDir);
+    if (!buildTarget && await existsAsync(tsconfigPath)) {
+      const buildTsconfig = await readJsonFile<any>(tsconfigPath);
+      buildTarget = buildTsconfig.compilerOptions?.target;
+    }
+
     // Generate the static ES module distribution sources
     // Note: this will bundle dependencies with code splitting, and **without** bare module specifiers
     await generateStaticESModuleSources({
       outdir: esbuildBuildDir,
+      target: buildTarget,
+      supported: config.context.build.esbuild.supported,
+      minify: config.context.build.esbuild.minify,
+      bundle: config.context.build.esbuild.bundle,
       entryPoints: [libEntry, ...componentEntries]
     });
   });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,6 +39,7 @@ export const DEFAULT_PROJECT_CONFIG: IProjectConfig = {
     },
     demo: { componentBundles: [] },
     rollup: {},
+    esbuild: {},
     tsconfigPath: `${DEFAULT_SRC_DIR_NAME}/${DEFAULT_LIB_DIR_NAME}/${DEFAULT_BUILD_TSCONFIG_NAME}`,
     static: {
       distPath: 'static'

--- a/src/core/definitions.ts
+++ b/src/core/definitions.ts
@@ -64,6 +64,7 @@ export interface ICopyFileDescriptor {
 export interface IBuildProjectConfig {
   webpack: IWebpackProjectConfig;
   rollup: IRollupProjectConfig;
+  esbuild: IEsbuildProjectConfig;
   tsconfigPath: string;
   demo: IProjectDemoConfig;
   static: IBuildStaticConfig;
@@ -88,6 +89,13 @@ export interface IWebpackSassLoaderConfig {
 }
 
 export interface IRollupProjectConfig {
+  bundle?: boolean;
+}
+
+export interface IEsbuildProjectConfig {
+  target?: string | string[];
+  supported?: Record<string, boolean>;
+  minify?: boolean;
   bundle?: boolean;
 }
 

--- a/src/utils/build-utils.ts
+++ b/src/utils/build-utils.ts
@@ -63,12 +63,21 @@ export async function lintTask(dir: string, stylelintConfigPath: string, eslint:
 /** Generates a bundled ES module build of the library. */
 export async function generateStaticESModuleSources({
   outdir,
+  target,
+  supported,
+  bundle = true,
+  minify = true,
   entryPoints,
   external,
   metafile,
   metafileOutDir
 }: {
   outdir: string;
+  target?: string | string[];
+  supported?: Record<string, boolean>;
+  bundle?: boolean;
+  minify?: boolean;
+  format?: string;
   metafile?: boolean;
   metafileOutDir?: string;
   entryPoints: string[] | Record<string, string>;
@@ -76,13 +85,14 @@ export async function generateStaticESModuleSources({
 }): Promise<void> {
   const result = await esbuild.build({
     format: 'esm',
-    target: 'es2017',
+    target,
+    supported,
     entryPoints,
     splitting: true,
     chunkNames: 'chunks/[name].[hash]',
     sourcemap: true,
-    bundle: true,
-    minify: true,
+    bundle,
+    minify,
     metafile,
     outdir,
     external


### PR DESCRIPTION
- Remove default `target` from esbuild compilation
- Pull default `target` from build tsconfig
- Update project configuration to allow for specifying the following esbuild options:
  - target
  - supported
  - minify
  - bundle