### PR TITLE
feat(build): add configuration to allow for controlling if static build artifacts are generated

### DIFF
--- a/config/schema.json
+++ b/config/schema.json
@@ -186,6 +186,11 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether to enable static build or not.",
+              "default": false
+            },
             "distPath": {
               "type": "string",
               "description": "The path within the `distDir` to generate static build assets to."

--- a/src/commands/build/build-command-utils.ts
+++ b/src/commands/build/build-command-utils.ts
@@ -101,31 +101,33 @@ export async function build({
     await compileTypeScriptTask(config, stagingSrcDir, stagingSrcDir, esmBuildDir, ts.ScriptTarget.ES2017, ts.ModuleKind.ES2015, true, typingsDir);
   }, quiet);
 
-  // Bundles the library with code-splitting to generate a self-contained ESM distribution
-  await runTask('Bundling ESM distribution sources...', async () => {
-    // Build the library entry points
-    const libEntry = join(stagingSrcDir, `${entryName}.ts`);
-    const componentEntries = await globFilesAsync(join(stagingSrcDir, '**/index.ts')) as string[];
+  if (config.context.build.static.enabled) {
+    // Bundles the library with code-splitting to generate a self-contained ESM distribution
+    await runTask('Bundling ESM distribution sources...', async () => {
+      // Build the library entry points
+      const libEntry = join(stagingSrcDir, `${entryName}.ts`);
+      const componentEntries = await globFilesAsync(join(stagingSrcDir, '**/index.ts')) as string[];
 
-    // Attempt to inherit the ES build target from the build tsconfig if we don't have one set in the project configuration
-    let buildTarget = config.context.build.esbuild.target;
-    const tsconfigPath = absolutify(config.context.build.tsconfigPath, config.context.paths.rootDir);
-    if (!buildTarget && await existsAsync(tsconfigPath)) {
-      const buildTsconfig = await readJsonFile<any>(tsconfigPath);
-      buildTarget = buildTsconfig.compilerOptions?.target;
-    }
+      // Attempt to inherit the ES build target from the build tsconfig if we don't have one set in the project configuration
+      let buildTarget = config.context.build.esbuild.target;
+      const tsconfigPath = absolutify(config.context.build.tsconfigPath, config.context.paths.rootDir);
+      if (!buildTarget && await existsAsync(tsconfigPath)) {
+        const buildTsconfig = await readJsonFile<any>(tsconfigPath);
+        buildTarget = buildTsconfig.compilerOptions?.target;
+      }
 
-    // Generate the static ES module distribution sources
-    // Note: this will bundle dependencies with code splitting, and **without** bare module specifiers
-    await generateStaticESModuleSources({
-      outdir: esbuildBuildDir,
-      target: buildTarget,
-      supported: config.context.build.esbuild.supported,
-      minify: config.context.build.esbuild.minify,
-      bundle: config.context.build.esbuild.bundle,
-      entryPoints: [libEntry, ...componentEntries]
+      // Generate the static ES module distribution sources
+      // Note: this will bundle dependencies with code splitting, and **without** bare module specifiers
+      await generateStaticESModuleSources({
+        outdir: esbuildBuildDir,
+        target: buildTarget,
+        supported: config.context.build.esbuild.supported,
+        minify: config.context.build.esbuild.minify,
+        bundle: config.context.build.esbuild.bundle,
+        entryPoints: [libEntry, ...componentEntries]
+      });
     });
-  });
+  }
 
   // Generates Custom Elements Manifest file.
   if (!config.context.customElementsManifestConfig?.disableAutoGeneration) {

--- a/src/commands/build/build-command.ts
+++ b/src/commands/build/build-command.ts
@@ -53,20 +53,24 @@ export class BuildCommand implements ICommand {
  * Builds the full library of components by bundling and creating an npm package.
  * @param {IConfig} config The environment configuration.
  */
-export async function buildCommand(ctx: IBuildTaskConfiguration): Promise<void> {
-  const buildRoot = join(ctx.context.paths.distBuildDir, FULL_BUILD_DIR_NAME);
+export async function buildCommand(config: IBuildTaskConfiguration): Promise<void> {
+  const buildRoot = join(config.context.paths.distBuildDir, FULL_BUILD_DIR_NAME);
   const buildOutputDir = join(buildRoot, TEMP_BUILD_DIR_NAME);
-  const srcDir = ctx.context.paths.libDir;
-  const packageJson = loadPackageJson(ctx.paths.rootDir);
-  const lintCode = assertBoolean(ctx.args.lint, true);
+  const srcDir = config.context.paths.libDir;
+  const packageJson = loadPackageJson(config.paths.rootDir);
+  const lintCode = assertBoolean(config.args.lint, true);
   
   if (lintCode) {
-    await lintTask(ctx.context.paths.libDir, ctx.context.paths.stylelintConfigPath, true, ctx.quiet);
+    await lintTask(config.context.paths.libDir, config.context.paths.stylelintConfigPath, true, config.quiet);
   }
 
-  await prebuild({ buildRoot, buildDir: buildRoot, buildOutputDir, srcDir, quiet: ctx.quiet });
-  await build({ config: ctx, buildOutputDir, quiet: ctx.quiet });
-  await createDistributionPackage({ config: ctx, packageJson, buildOutputDir });
-  await copyBundledDistributionAssets({ config: ctx, packageJson, buildOutputDir });
-  await cleanup(buildOutputDir, ctx.quiet);
+  await prebuild({ buildRoot, buildDir: buildRoot, buildOutputDir, srcDir, quiet: config.quiet });
+  await build({ config, buildOutputDir, quiet: config.quiet });
+  await createDistributionPackage({ config, packageJson, buildOutputDir });
+
+  if (config.context.build.static.enabled) {
+    await copyBundledDistributionAssets({ config, packageJson, buildOutputDir });
+  }
+  
+  await cleanup(buildOutputDir, config.quiet);
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,6 +42,7 @@ export const DEFAULT_PROJECT_CONFIG: IProjectConfig = {
     esbuild: {},
     tsconfigPath: `${DEFAULT_SRC_DIR_NAME}/${DEFAULT_LIB_DIR_NAME}/${DEFAULT_BUILD_TSCONFIG_NAME}`,
     static: {
+      enabled: true,
       distPath: 'static'
     }
   },

--- a/src/core/definitions.ts
+++ b/src/core/definitions.ts
@@ -81,6 +81,7 @@ export interface IWebpackProjectConfig {
 }
 
 export interface IBuildStaticConfig {
+  enabled: boolean;
   distPath: string;
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? 

## Describe the new behavior?
Added new project configuration to allow for controlling whether the static build (bundled ESM) artifacts are generated in the distribution package.

```json
{
  "build": {
    "static": {
      "enabled": false // `true` by default
    },
  }
}
```

## Additional information
Set this to `false` to disable static bundling of ESM distribution sources (typically used for hosting on a static server or CDN.
